### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: nervebing/release-downloader


### PR DESCRIPTION
Potential fix for [https://github.com/NERVEbing/release-downloader/security/code-scanning/4](https://github.com/NERVEbing/release-downloader/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the workflow's steps, the following permissions are needed:
- `contents: read` to allow the workflow to access the repository's contents.
- `packages: write` to allow the workflow to push Docker images to the GitHub Container Registry.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
