### PR TITLE
Guard asset date renaming when UpdatedAt is zero

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -104,7 +104,10 @@ func fetchFiles(m map[string][]*github.ReleaseAsset) error {
 				assetName = fileRename(assetName, tag)
 			}
 			if c.assetDate {
-				assetName = fileRename(assetName, asset.UpdatedAt.Format("200601021504"))
+				updatedAt := asset.GetUpdatedAt()
+				if !updatedAt.IsZero() {
+					assetName = fileRename(assetName, updatedAt.Format("200601021504"))
+				}
 			}
 			assetURL := asset.GetBrowserDownloadURL()
 			assetPath := filepath.Join(c.path, assetName)


### PR DESCRIPTION
### Motivation
- Prevent a panic when an asset's update timestamp is missing or zero by avoiding direct access to `asset.UpdatedAt`.
- Use the safe accessor `GetUpdatedAt()` and decide a fallback behavior instead of assuming a valid timestamp.

### Description
- Replaced `asset.UpdatedAt.Format("200601021504")` with a safe access using `updatedAt := asset.GetUpdatedAt()` in `fetch.go`.
- Only call `updatedAt.Format(...)` when `updatedAt.IsZero()` is false, otherwise skip the date-based renaming.
- No other behavior changes to download, extraction, or cleaning logic were made.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b1f2111388321a500fd8d931c866b)