### PR TITLE
Align README `-asset_date` examples with code timestamp format

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ go build -o release-downloader .
 | `-once`           | `RD_ONCE`            | `false`           | Run once and exit.                                                                           |
 | `-timeout`        | `RD_TIMEOUT`         | `DefaultTimeout`  | HTTP client timeout (e.g., `30s`, `2m`).                                                     |
 | `-asset_tag`      | `RD_ASSET_TAG`       | `false`           | Append release tag to filename (e.g., `file.zip` → `file-v1.0.0.zip`).                       |
-| `-asset_date`     | `RD_ASSET_DATE`      | `false`           | Append download date to filename (e.g., `file.zip` → `file-20240502.zip`).                   |
+| `-asset_date`     | `RD_ASSET_DATE`      | `false`           | Append download date to filename (e.g., `file.zip` → `file-202405021530.zip`).               |
 | `-asset_extract`  | `RD_ASSET_EXTRACT`   | `false`           | Auto-extract downloaded files (supports `.zip`, `.gz`, `.tar.gz`).                           |
 | `-autoclean`      | `RD_AUTOCLEAN`       | `false`           | Remove old release files after downloading a new one.                                        |
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -66,7 +66,7 @@ go build -o release-downloader .
 | `-once`          | `RD_ONCE`          | `false`           | 运行一次后退出。                                                                          |
 | `-timeout`       | `RD_TIMEOUT`       | `DefaultTimeout`  | HTTP 客户端超时时间（如 `30s`、`2m`）。                                                   |
 | `-asset_tag`     | `RD_ASSET_TAG`     | `false`           | 在文件名后追加版本标签（如 `file.zip` → `file-v1.0.0.zip`）。                             |
-| `-asset_date`    | `RD_ASSET_DATE`    | `false`           | 在文件名后追加下载日期（如 `file.zip` → `file-20240502.zip`）。                           |
+| `-asset_date`    | `RD_ASSET_DATE`    | `false`           | 在文件名后追加下载日期（如 `file.zip` → `file-202405021530.zip`）。                       |
 | `-asset_extract` | `RD_ASSET_EXTRACT` | `false`           | 自动解压下载的文件（支持 `.zip`、`.gz`、`.tar.gz`）。                                     |
 | `-autoclean`     | `RD_AUTOCLEAN`     | `false`           | 下载新版本文件后，自动清理旧的 release 文件。                                             |
 


### PR DESCRIPTION
### Motivation
- The `-asset_date` examples in the docs showed a date-only format, while the code in `fetch.go` formats asset timestamps as `200601021504` (YYYYMMDDHHMM). 
- Update documentation to match the actual filename behavior produced at runtime to avoid confusion. 
- Ensure English and Chinese README files are consistent with each other and with the code.

### Description
- Updated the `-asset_date` example in `README.md` to use a timestamp example like `file-202405021530.zip`.
- Updated the `-asset_date` example in `README.zh.md` to the matching timestamp example `file-202405021530.zip`.
- No code changes were made; this aligns the docs with the existing `asset.UpdatedAt.Format("200601021504")` behavior in `fetch.go`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b1f74a38c8321b1c133a0513ca4a5)