### PR TITLE
Add table-driven tests for matchPattern

### DIFF
--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,58 @@
+package main
+
+import "testing"
+
+func TestMatchPattern(t *testing.T) {	tests := []struct {
+		name        string
+		str         string
+		pattern     string
+		wantMatch   bool
+		wantErr     bool
+	}{
+		{
+			name:      "exact match",
+			str:       "linux-amd64",
+			pattern:   "linux-amd64",
+			wantMatch: true,
+		},
+		{
+			name:      "regex match",
+			str:       "linux-amd64",
+			pattern:   "linux.*",
+			wantMatch: true,
+		},
+		{
+			name:    "invalid regex",
+			str:     "linux-amd64",
+			pattern: "[",
+			wantErr: true,
+		},
+		{
+			name:      "substring but not regex",
+			str:       "linux-amd64",
+			pattern:   "linux",
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			match, err := matchPattern(tt.str, tt.pattern)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if match != tt.wantMatch {
+				t.Fatalf("match = %v, want %v", match, tt.wantMatch)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation

- Verify `matchPattern` behaviour across its key branches to prevent regressions.
- Ensure exact equality, regex matching, invalid regex handling, and substring-only cases are explicitly specified.
- Clarify expected return values (`bool` and `error`) for common inputs.

### Description

- Add a new test file `util_test.go` in package `main` with `TestMatchPattern` using the Go `testing` package.
- Implement table-driven subtests via `t.Run` that cover exact match, regex match, invalid regex (expect error), and substring-but-not-regex cases.
- Each case asserts the returned `bool` and `error` against the expected outcomes.

### Testing

- Added automated tests in `util_test.go` containing the table-driven `TestMatchPattern` suite.
- Ran `go test ./...`, which hung with no output and was interrupted, so the test run did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b1f7b5074832185f9c316145bea82)